### PR TITLE
feat: adiciona detalhes e investimento de startups

### DIFF
--- a/mobile/lib/app/routes.dart
+++ b/mobile/lib/app/routes.dart
@@ -8,7 +8,9 @@ import '../features/auth/presentation/pages/token_verification_page.dart';
 import '../features/perfil/presentation/pages/perfil_page.dart';
 import '../features/auth/presentation/pages/splash_page.dart';
 import '../features/auth/presentation/pages/mfa_challenge_page.dart';
+import '../features/startups/domain/startup_model.dart';
 import '../features/startups/presentation/pages/catalog_page.dart';
+import '../features/startups/presentation/pages/startup_details_page.dart';
 import '../features/perfil/presentation/pages/informacoes_pessoais_page.dart';
 import '../features/perfil/presentation/pages/mfa_page.dart';
 import '../features/perfil/presentation/pages/senha_page.dart';
@@ -24,6 +26,7 @@ class AppRoutes {
   static const tokenVerification = '/token-verification';
   static const perfil = '/perfil';
   static const catalog = '/catalog';
+  static const startupDetail = '/startup-detail';
   static const informacoesPessoais = '/informacoes-pessoais';
   static const mfa = '/mfa';
   static const mfaChallenge = '/mfa-challenge';
@@ -40,6 +43,13 @@ class AppRoutes {
     tokenVerification: (_) => TokenVerificationPage(),
     perfil: (_) => PerfilPage(),
     catalog: (_) => CatalogPage(),
+    startupDetail: (context) {
+      final startup = ModalRoute.of(context)?.settings.arguments;
+      if (startup is Startup) {
+        return StartupDetailsPage(startup: startup);
+      }
+      return const StartupDetailsArgumentErrorPage();
+    },
     informacoesPessoais: (_) => InformacoesPage(),
     mfa: (_) => MfaPage(),
     mfaChallenge: (_) => MfaChallengePage(),

--- a/mobile/lib/features/startups/data/startup_service.dart
+++ b/mobile/lib/features/startups/data/startup_service.dart
@@ -1,23 +1,23 @@
 import 'dart:convert';
 import 'dart:io' show Platform;
+
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:http/http.dart' as http;
+
 import '../domain/startup_model.dart';
 import 'startup_mock.dart';
 
 class StartupService {
-  // URL base do backend
   static String get _baseUrl {
     if (kIsWeb) {
-      return 'https://localhost:3000';
+      return 'http://localhost:3000/v1';
     } else if (Platform.isAndroid) {
-      return 'https://10.0.2.2:3000'; // é para o emulador de android
+      return 'http://10.0.2.2:3000/v1';
     } else {
-      return 'https://127.0.0.1:3000'; // para emulador de ios( provavelmente eu vou tirar isso por não ter que testar no ios)
+      return 'http://127.0.0.1:3000/v1';
     }
   }
 
-  // Busca todas as startups, com filtro opcional por estágio
   Future<List<Startup>> listarStartups({String? estagio}) async {
     if (kUseMock) {
       await Future.delayed(const Duration(milliseconds: 600));
@@ -44,9 +44,56 @@ class StartupService {
         rethrow;
       }
       throw StartupApiException(
-        'Erro de conexão com o servidor. Verifique sua internet.',
+        'Erro de conexao com o servidor. Verifique sua internet.',
       );
     }
+  }
+
+  Future<Startup> buscarStartupPorId(String startupId) async {
+    if (kUseMock) {
+      await Future.delayed(const Duration(milliseconds: 600));
+      return mockStartups.firstWhere(
+        (startup) => startup.id == startupId,
+        orElse: () => throw StartupApiException(
+          'Startup nao encontrada.',
+          404,
+        ),
+      );
+    }
+
+    final url = Uri.parse('$_baseUrl/startups/$startupId');
+
+    try {
+      final response = await http.get(url);
+
+      if (response.statusCode == 200) {
+        final body = jsonDecode(response.body);
+        return Startup.fromJson(body['data']);
+      } else if (response.statusCode == 404) {
+        throw StartupApiException('Startup nao encontrada.', 404);
+      } else {
+        throw StartupApiException(
+          'Erro ao buscar startup: ${response.statusCode}',
+          response.statusCode,
+        );
+      }
+    } catch (e) {
+      if (e is StartupApiException) {
+        rethrow;
+      }
+      throw StartupApiException(
+        'Erro de conexao com o servidor. Verifique sua internet.',
+      );
+    }
+  }
+
+  Future<bool> investirStartup(String startupId, double valorAInvestir) async {
+    if (startupId.trim().isEmpty || valorAInvestir.isNaN) {
+      return false;
+    }
+
+    await Future.delayed(const Duration(seconds: 2));
+    return true;
   }
 }
 

--- a/mobile/lib/features/startups/domain/startup_model.dart
+++ b/mobile/lib/features/startups/domain/startup_model.dart
@@ -85,6 +85,10 @@ class Startup {
   final String logo;
   final String descricao;
   final String estagio;
+  final String setor;
+  final double precoToken;
+  final double? variacaoPreco;
+  final bool investido;
   final double capitalAportado;
   final int totalTokens;
   final String resumoExecutivo;
@@ -100,6 +104,10 @@ class Startup {
     required this.logo,
     required this.descricao,
     required this.estagio,
+    this.setor = '',
+    this.precoToken = 0,
+    this.variacaoPreco,
+    this.investido = false,
     required this.capitalAportado,
     required this.totalTokens,
     required this.resumoExecutivo,
@@ -117,6 +125,15 @@ class Startup {
       logo: json['logo'] ?? '',
       descricao: json['descricao'] ?? '',
       estagio: json['estagio'] ?? '',
+      setor: json['setor'] ?? '',
+      precoToken: _doubleFromJson(
+        json['precoToken'] ?? json['precoTokenAtualCentavos'],
+        fromCentavos: json['precoToken'] == null,
+      ),
+      variacaoPreco: json['variacaoPreco'] == null
+          ? null
+          : _doubleFromJson(json['variacaoPreco']),
+      investido: json['investido'] == true,
       capitalAportado: (json['capitalAportado'] ?? 0).toDouble(),
       totalTokens: json['totalTokens'] ?? 0,
       resumoExecutivo: json['resumoExecutivo'] ?? '',
@@ -137,5 +154,11 @@ class Startup {
           .map((a) => Atualizacao.fromJson(a))
           .toList(),
     );
+  }
+
+  static double _doubleFromJson(dynamic value, {bool fromCentavos = false}) {
+    if (value == null) return 0;
+    final number = value is num ? value.toDouble() : double.tryParse('$value') ?? 0;
+    return fromCentavos ? number / 100 : number;
   }
 }

--- a/mobile/lib/features/startups/presentation/pages/catalog_page.dart
+++ b/mobile/lib/features/startups/presentation/pages/catalog_page.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:mesclainvest/app/routes.dart';
+import 'package:mesclainvest/core/theme/app_colors.dart';
+
 import '../../data/startup_service.dart';
 import '../../domain/startup_model.dart';
 import '../widgets/startup_card.dart';
 
-/// Estado possível da tela de catálogo separando em 3
 enum CatalogState { loading, error, success }
 
-/// Tela principal do catálogo de startups do MesclaInvest
 class CatalogPage extends StatefulWidget {
   const CatalogPage({super.key});
 
@@ -15,74 +16,130 @@ class CatalogPage extends StatefulWidget {
 }
 
 class _CatalogPageState extends State<CatalogPage> {
-  /// Serviço responsável pelas chamadas HTTP ao backend
   final StartupService _service = StartupService();
+  final TextEditingController _searchController = TextEditingController();
 
-  /// Lista de startups retornadas pela API
   List<Startup> _startups = [];
-
-  /// Estado atual da tela.
   CatalogState _state = CatalogState.loading;
-
-  // tratamento de erro
   String? _errorMessage;
 
   String? _selectedStage;
+  final Set<String> _selectedSectors = {};
+  String _sortBy = 'recentes';
 
-  static const List<String> _stages = [
-    'Todos',
+  static const List<String> _stageOptions = [
     'Nova',
     'Em Operação',
     'Em Expansão',
+  ];
+
+  static const List<String> _sectorOptions = [
+    'Sustentabilidade',
+    'Saúde',
+    'Educação',
+    'Fintech',
+    'Agritech',
+    'Mobilidade',
   ];
 
   @override
   void initState() {
     super.initState();
     _fetchStartups();
+    _searchController.addListener(() => setState(() {}));
   }
 
-  /// Busca startups na API aplicando o filtro de estágio atual
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
   Future<void> _fetchStartups() async {
     setState(() {
       _state = CatalogState.loading;
       _errorMessage = null;
+      _startups = [];
     });
 
     try {
-      final startups = await _service.listarStartups(
-        estagio: _selectedStage,
-      );
+      final startups = await _service.listarStartups(estagio: _selectedStage);
+      final seen = <String>{};
 
       setState(() {
-        _startups = startups;
+        _startups = startups.where((s) => seen.add(s.id)).toList();
         _state = CatalogState.success;
       });
     } catch (e) {
       setState(() {
-        _errorMessage = 'Não foi possível carregar as startups.\n'
-            'Verifique sua conexão e tente novamente.';
+        _errorMessage =
+            'Não foi possível carregar as startups.\nVerifique sua conexão e tente novamente.';
         _state = CatalogState.error;
       });
     }
   }
 
-  /// Atualiza o filtro selecionado e recarrega as startups
-  void _onStageSelected(String stage) {
-    final selected = stage == 'Todos' ? null : stage;
+  List<Startup> get _filteredStartups {
+    var list = List<Startup>.from(_startups);
 
-    if (selected == _selectedStage) return;
+    final query = _searchController.text.trim().toLowerCase();
+    if (query.isNotEmpty) {
+      list = list
+          .where(
+            (s) =>
+                s.nome.toLowerCase().contains(query) ||
+                s.setor.toLowerCase().contains(query),
+          )
+          .toList();
+    }
 
-    setState(() => _selectedStage = selected);
-    _fetchStartups();
+    if (_selectedSectors.isNotEmpty) {
+      list = list.where((s) => _selectedSectors.contains(s.setor)).toList();
+    }
+
+    if (_sortBy == 'preco') {
+      list.sort((a, b) => b.precoToken.compareTo(a.precoToken));
+    }
+
+    return list;
   }
 
-  /// Navega para a tela de detalhe da [startup] selecionada
   void _onStartupTapped(Startup startup) {
     Navigator.pushNamed(
       context,
-      '/startup-detail',
+      AppRoutes.startupDetail,
       arguments: startup,
+    );
+  }
+
+  void _showFilterSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.white,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => _FilterSheet(
+        selectedStage: _selectedStage,
+        selectedSectors: Set.of(_selectedSectors),
+        sortBy: _sortBy,
+        stageOptions: _stageOptions,
+        sectorOptions: _sectorOptions,
+        onApply: (stage, sectors, sortBy) {
+          final stageChanged = stage != _selectedStage;
+
+          setState(() {
+            _selectedStage = stage;
+            _selectedSectors
+              ..clear()
+              ..addAll(sectors);
+            _sortBy = sortBy;
+          });
+
+          if (stageChanged) _fetchStartups();
+        },
+      ),
     );
   }
 
@@ -95,7 +152,6 @@ class _CatalogPageState extends State<CatalogPage> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildHeader(),
-            _buildStageFilters(),
             _buildResultCount(),
             Expanded(child: _buildContent()),
           ],
@@ -104,35 +160,62 @@ class _CatalogPageState extends State<CatalogPage> {
     );
   }
 
-  /// Constrói o cabeçalho com título e subtítulo do catálogo
   Widget _buildHeader() {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.fromLTRB(20, 24, 20, 20),
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          colors: [Color(0xFFE91E8C), Color(0xFFC2185B)],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+    return ClipRect(
+      child: Stack(
         children: [
-          const Text(
-            'Catálogo de Startups',
-            style: TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-              color: Colors.white,
+          Positioned.fill(
+            child: Container(color: const Color(0xFFAD1457)),
+          ),
+          Positioned(
+            top: -55,
+            right: -45,
+            child: Container(
+              width: 210,
+              height: 210,
+              decoration: BoxDecoration(
+                color: const Color(0xFFE91E8C).withValues(alpha: 0.22),
+                shape: BoxShape.circle,
+              ),
             ),
           ),
-          const SizedBox(height: 4),
-          Text(
-            'Ecossistema Mescla · PUC-Campinas',
-            style: TextStyle(
-              fontSize: 13,
-              color: Colors.white.withValues(alpha: 0.85),
+          Positioned(
+            bottom: -18,
+            right: 55,
+            child: Container(
+              width: 95,
+              height: 95,
+              decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.07),
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Catálogo de Startups',
+                  style: TextStyle(
+                    fontSize: 22,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  'Ecossistema Mescla · PUC-Campinas',
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Colors.white.withValues(alpha: 0.85),
+                  ),
+                ),
+                const SizedBox(height: 14),
+                _buildSearchBar(),
+              ],
             ),
           ),
         ],
@@ -140,88 +223,98 @@ class _CatalogPageState extends State<CatalogPage> {
     );
   }
 
-  /// Constrói a barra de filtros por estágio de desenvolvimento
-  Widget _buildStageFilters() {
-    return SizedBox(
-      height: 52,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        itemCount: _stages.length,
-        itemBuilder: (context, index) {
-          final stage = _stages[index];
-          final isActive = stage == 'Todos'
-              ? _selectedStage == null
-              : _selectedStage == stage;
-
-          return GestureDetector(
-            onTap: () => _onStageSelected(stage),
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 200),
-              margin: const EdgeInsets.only(right: 8),
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              decoration: BoxDecoration(
-                color: isActive
-                    ? const Color(0xFFE91E8C)
-                    : Colors.white,
-                borderRadius: BorderRadius.circular(20),
-                border: Border.all(
-                  color: isActive
-                      ? const Color(0xFFE91E8C)
-                      : Colors.grey[300]!,
+  Widget _buildSearchBar() {
+    return Container(
+      height: 44,
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(22),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.08),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          const SizedBox(width: 14),
+          const Icon(
+            Icons.search_rounded,
+            size: 20,
+            color: AppColors.mutedForeground,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              controller: _searchController,
+              style: const TextStyle(fontSize: 13, color: Color(0xFF1E293B)),
+              decoration: const InputDecoration(
+                hintText: 'Buscar startups ou setores...',
+                hintStyle: TextStyle(
+                  fontSize: 13,
+                  color: AppColors.mutedForeground,
                 ),
-              ),
-              child: Center(
-                child: Text(
-                  stage,
-                  style: TextStyle(
-                    fontSize: 12,
-                    fontWeight: FontWeight.w600,
-                    color: isActive ? Colors.white : Colors.grey[600],
-                  ),
-                ),
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: EdgeInsets.zero,
               ),
             ),
-          );
-        },
+          ),
+          const VerticalDivider(
+            width: 1,
+            thickness: 1,
+            color: Color(0xFFE2E8F0),
+          ),
+          GestureDetector(
+            onTap: _showFilterSheet,
+            child: const SizedBox(
+              width: 44,
+              height: 44,
+              child: Icon(
+                Icons.filter_alt_rounded,
+                size: 20,
+                color: AppColors.primary,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }
 
-  /// Constrói o contador de resultados abaixo dos filtros.
   Widget _buildResultCount() {
+    final filtered = _filteredStartups;
     final label = _state == CatalogState.loading
         ? 'Carregando...'
-        : '${_startups.length} startup${_startups.length != 1 ? 's' : ''} encontrada${_startups.length != 1 ? 's' : ''}';
+        : '${filtered.length} startup${filtered.length != 1 ? 's' : ''} encontrada${filtered.length != 1 ? 's' : ''}';
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
       child: Text(
         label,
-        style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+        style: const TextStyle(
+          fontSize: 13,
+          color: AppColors.mutedForeground,
+        ),
       ),
     );
   }
 
-  /// Constrói o conteúdo principal da tela conforme o [_state] atual
   Widget _buildContent() {
     switch (_state) {
       case CatalogState.loading:
         return const Center(
-          child: CircularProgressIndicator(
-            color: Color(0xFFE91E8C),
-          ),
+          child: CircularProgressIndicator(color: AppColors.primary),
         );
-
       case CatalogState.error:
         return _buildErrorState();
-
       case CatalogState.success:
         return _buildStartupList();
     }
   }
 
-  /// Constrói o estado de erro com mensagem e botão para tentar novamente
   Widget _buildErrorState() {
     return Center(
       child: Padding(
@@ -229,14 +322,18 @@ class _CatalogPageState extends State<CatalogPage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.cloud_off_rounded, size: 56, color: Colors.grey[400]),
+            const Icon(
+              Icons.cloud_off_rounded,
+              size: 56,
+              color: AppColors.muted,
+            ),
             const SizedBox(height: 16),
             Text(
               _errorMessage ?? 'Erro desconhecido.',
               textAlign: TextAlign.center,
-              style: TextStyle(
+              style: const TextStyle(
                 fontSize: 14,
-                color: Colors.grey[600],
+                color: AppColors.mutedForeground,
                 height: 1.5,
               ),
             ),
@@ -246,7 +343,7 @@ class _CatalogPageState extends State<CatalogPage> {
               icon: const Icon(Icons.refresh_rounded),
               label: const Text('Tentar novamente'),
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFFE91E8C),
+                backgroundColor: AppColors.primary,
                 foregroundColor: Colors.white,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(20),
@@ -259,19 +356,24 @@ class _CatalogPageState extends State<CatalogPage> {
     );
   }
 
-  /// Exibe um estado vazio quando nenhuma startup é retornada pela API
   Widget _buildStartupList() {
-    if (_startups.isEmpty) {
-      return Center(
+    final list = _filteredStartups;
+
+    if (list.isEmpty) {
+      return const Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.search_off_rounded, size: 56, color: Colors.grey[400]),
-            const SizedBox(height: 16),
+            Icon(
+              Icons.search_off_rounded,
+              size: 56,
+              color: AppColors.muted,
+            ),
+            SizedBox(height: 16),
             Text(
               'Nenhuma startup encontrada\npara o filtro selecionado.',
               textAlign: TextAlign.center,
-              style: TextStyle(fontSize: 14, color: Colors.grey[600]),
+              style: TextStyle(fontSize: 14, color: AppColors.mutedForeground),
             ),
           ],
         ),
@@ -279,17 +381,263 @@ class _CatalogPageState extends State<CatalogPage> {
     }
 
     return RefreshIndicator(
-      color: const Color(0xFFE91E8C),
+      color: AppColors.primary,
       onRefresh: _fetchStartups,
       child: ListView.builder(
-        padding: const EdgeInsets.only(top: 8, bottom: 24),
-        itemCount: _startups.length,
-        itemBuilder: (context, index) {
-          return StartupCard(
-            startup: _startups[index],
-            onTap: () => _onStartupTapped(_startups[index]),
-          );
-        },
+        padding: const EdgeInsets.only(top: 4, bottom: 24),
+        itemCount: list.length,
+        itemBuilder: (context, index) => StartupCard(
+          startup: list[index],
+          onTap: () => _onStartupTapped(list[index]),
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterSheet extends StatefulWidget {
+  final String? selectedStage;
+  final Set<String> selectedSectors;
+  final String sortBy;
+  final List<String> stageOptions;
+  final List<String> sectorOptions;
+  final void Function(String? stage, Set<String> sectors, String sortBy) onApply;
+
+  const _FilterSheet({
+    required this.selectedStage,
+    required this.selectedSectors,
+    required this.sortBy,
+    required this.stageOptions,
+    required this.sectorOptions,
+    required this.onApply,
+  });
+
+  @override
+  State<_FilterSheet> createState() => _FilterSheetState();
+}
+
+class _FilterSheetState extends State<_FilterSheet> {
+  late String? _stage;
+  late Set<String> _sectors;
+  late String _sortBy;
+
+  @override
+  void initState() {
+    super.initState();
+    _stage = widget.selectedStage;
+    _sectors = Set.of(widget.selectedSectors);
+    _sortBy = widget.sortBy;
+  }
+
+  String _stageLabel(String stage) {
+    switch (stage) {
+      case 'Em Expansão':
+        return 'Expansão';
+      case 'Em Operação':
+        return 'Operação';
+      default:
+        return stage;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 0, 20, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              margin: const EdgeInsets.symmetric(vertical: 12),
+              width: 36,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppColors.muted,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Filtros',
+                style: TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w700,
+                  color: Color(0xFF1E293B),
+                ),
+              ),
+              GestureDetector(
+                onTap: () => Navigator.pop(context),
+                child: Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: AppColors.secondary,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: const Icon(
+                    Icons.close_rounded,
+                    size: 18,
+                    color: AppColors.mutedForeground,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          _buildSectionLabel('Estágio da Startup'),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: widget.stageOptions.map((stage) {
+              final selected = _stage == stage;
+              return _FilterChip(
+                label: _stageLabel(stage),
+                selected: selected,
+                onTap: () => setState(() => _stage = selected ? null : stage),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 20),
+          _buildSectionLabel('Setor'),
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: widget.sectorOptions.map((sector) {
+              final selected = _sectors.contains(sector);
+              return _FilterChip(
+                label: sector,
+                selected: selected,
+                onTap: () => setState(() {
+                  if (selected) {
+                    _sectors.remove(sector);
+                  } else {
+                    _sectors.add(sector);
+                  }
+                }),
+              );
+            }).toList(),
+          ),
+          const SizedBox(height: 20),
+          _buildSectionLabel('Ordenar por'),
+          const SizedBox(height: 10),
+          _buildSortOption('recentes', 'Mais recentes'),
+          const SizedBox(height: 8),
+          _buildSortOption('preco', 'Preço'),
+          const SizedBox(height: 24),
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context);
+                widget.onApply(_stage, _sectors, _sortBy);
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                foregroundColor: Colors.white,
+                elevation: 0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: const Text(
+                'Aplicar filtros',
+                style: TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionLabel(String label) {
+    return Text(
+      label,
+      style: const TextStyle(
+        fontSize: 13,
+        fontWeight: FontWeight.w600,
+        color: AppColors.mutedForeground,
+      ),
+    );
+  }
+
+  Widget _buildSortOption(String value, String label) {
+    final selected = _sortBy == value;
+
+    return GestureDetector(
+      onTap: () => setState(() => _sortBy = value),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: selected ? AppColors.primary : const Color(0xFFE2E8F0),
+          ),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: selected ? Colors.white : const Color(0xFF1E293B),
+              ),
+            ),
+            if (selected)
+              const Icon(Icons.check_rounded, size: 18, color: Colors.white),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _FilterChip({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : Colors.white,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(
+            color: selected ? AppColors.primary : const Color(0xFFE2E8F0),
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w500,
+            color: selected ? Colors.white : const Color(0xFF475569),
+          ),
+        ),
       ),
     );
   }

--- a/mobile/lib/features/startups/presentation/pages/startup_details_page.dart
+++ b/mobile/lib/features/startups/presentation/pages/startup_details_page.dart
@@ -1,0 +1,727 @@
+import 'package:flutter/material.dart';
+import 'package:mesclainvest/core/theme/app_colors.dart';
+
+import '../../data/startup_service.dart';
+import '../../domain/startup_model.dart';
+
+class StartupDetailsPage extends StatefulWidget {
+  final Startup startup;
+
+  const StartupDetailsPage({
+    super.key,
+    required this.startup,
+  });
+
+  @override
+  State<StartupDetailsPage> createState() => _StartupDetailsPageState();
+}
+
+class _StartupDetailsPageState extends State<StartupDetailsPage> {
+  final StartupService _service = StartupService();
+
+  late Startup _startup;
+  bool _isLoading = true;
+  bool _isInvesting = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _startup = widget.startup;
+    _fetchStartupDetails();
+  }
+
+  Future<void> _fetchStartupDetails() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final startup = await _service.buscarStartupPorId(widget.startup.id);
+
+      if (!mounted) return;
+      setState(() {
+        _startup = startup;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _errorMessage = e is StartupApiException
+            ? e.message
+            : 'Não foi possível carregar os detalhes da startup.';
+      });
+    }
+  }
+
+  Future<void> _showInvestConfirmation() async {
+    const saldoUsuario = 5000.0;
+    const investimentoMinimo = 500.0;
+    const valorRecomendado = 1000.0;
+
+    final valorController = TextEditingController(
+      text: valorRecomendado.toStringAsFixed(0),
+    );
+
+    double valorDigitado() {
+      final normalized = valorController.text.replaceAll(',', '.');
+      return double.tryParse(normalized) ?? 0;
+    }
+
+    final valorAInvestir = await showDialog<double>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            final valor = valorDigitado();
+            final saldoInsuficiente = valor > saldoUsuario;
+            final abaixoDoMinimo = valor < investimentoMinimo;
+            final podeConfirmar = !saldoInsuficiente && !abaixoDoMinimo;
+
+            return AlertDialog(
+              title: const Text('Confirmar investimento'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Deseja confirmar o investimento nesta startup?',
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Saldo disponível: ${saldoUsuario.toStringAsFixed(0)} tokens',
+                  ),
+                  Text(
+                    'Investimento mínimo: ${investimentoMinimo.toStringAsFixed(0)} tokens',
+                  ),
+                  Text(
+                    'Valor recomendado: ${valorRecomendado.toStringAsFixed(0)} tokens',
+                  ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: valorController,
+                    keyboardType: const TextInputType.numberWithOptions(
+                      decimal: true,
+                    ),
+                    decoration: const InputDecoration(
+                      labelText: 'Valor a investir',
+                      suffixText: 'tokens',
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: (_) => setDialogState(() {}),
+                  ),
+                  if (saldoInsuficiente) ...[
+                    const SizedBox(height: 8),
+                    const Text(
+                      'Saldo insuficiente para esta operação.',
+                      style: TextStyle(color: Colors.red),
+                    ),
+                    TextButton(
+                      onPressed: () {
+                        print('TODO: Redirecionar para compra de tokens');
+                      },
+                      child: const Text('Comprar mais tokens'),
+                    ),
+                  ],
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text('Cancelar'),
+                ),
+                ElevatedButton(
+                  onPressed: podeConfirmar
+                      ? () => Navigator.pop(context, valor)
+                      : null,
+                  child: const Text('Confirmar'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    valorController.dispose();
+
+    if (valorAInvestir == null || !mounted) return;
+
+    setState(() => _isInvesting = true);
+
+    final success = await _service.investirStartup(
+      _startup.id,
+      valorAInvestir,
+    );
+
+    if (!mounted) return;
+
+    setState(() => _isInvesting = false);
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Investimento realizado com sucesso!'),
+          backgroundColor: Colors.green,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      appBar: AppBar(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        title: Text(
+          _startup.nome,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppColors.primary),
+      );
+    }
+
+    if (_errorMessage != null) {
+      return _DetailsErrorState(
+        message: _errorMessage!,
+        onRetry: _fetchStartupDetails,
+      );
+    }
+
+    return _DetailsContent(
+      startup: _startup,
+      isInvesting: _isInvesting,
+      onInvestPressed: _showInvestConfirmation,
+    );
+  }
+}
+
+class StartupDetailsArgumentErrorPage extends StatelessWidget {
+  const StartupDetailsArgumentErrorPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Nenhuma startup selecionada.'),
+      ),
+    );
+  }
+}
+
+class _DetailsContent extends StatelessWidget {
+  final Startup startup;
+  final bool isInvesting;
+  final VoidCallback onInvestPressed;
+
+  const _DetailsContent({
+    required this.startup,
+    required this.isInvesting,
+    required this.onInvestPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        _DetailsHeader(startup: startup),
+        const SizedBox(height: 16),
+        _InfoSection(
+          title: 'Resumo executivo',
+          child: Text(
+            startup.resumoExecutivo.isEmpty
+                ? startup.descricao
+                : startup.resumoExecutivo,
+            style: const TextStyle(
+              fontSize: 14,
+              height: 1.5,
+              color: AppColors.foreground,
+            ),
+          ),
+        ),
+        const SizedBox(height: 12),
+        _InfoSection(
+          title: 'Indicadores',
+          child: Row(
+            children: [
+              Expanded(
+                child: _MetricTile(
+                  icon: Icons.attach_money_rounded,
+                  label: 'Capital',
+                  value: _formatCurrency(startup.capitalAportado),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: _MetricTile(
+                  icon: Icons.toll_rounded,
+                  label: 'Tokens',
+                  value: _formatTokens(startup.totalTokens),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (startup.socios.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _PeopleSection(title: 'Socios', people: startup.socios),
+        ],
+        if (startup.conselho.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _MembersSection(title: 'Conselho', members: startup.conselho),
+        ],
+        if (startup.mentores.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _MembersSection(title: 'Mentores', members: startup.mentores),
+        ],
+        if (startup.atualizacoes.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          _UpdatesSection(updates: startup.atualizacoes),
+        ],
+        const SizedBox(height: 16),
+        SizedBox(
+          width: double.infinity,
+          height: 48,
+          child: ElevatedButton(
+            onPressed: isInvesting ? null : onInvestPressed,
+            child: isInvesting
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Investir'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DetailsErrorState extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _DetailsErrorState({
+    required this.message,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.cloud_off_rounded, size: 56, color: Colors.grey[400]),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 14,
+                color: Colors.grey[600],
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh_rounded),
+              label: const Text('Tentar novamente'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailsHeader extends StatelessWidget {
+  final Startup startup;
+
+  const _DetailsHeader({required this.startup});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.card,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _StartupLogo(url: startup.logo, size: 64),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  startup.nome,
+                  style: const TextStyle(
+                    fontSize: 20,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.foreground,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  startup.descricao,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    height: 1.4,
+                    color: AppColors.mutedForeground,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                _StageChip(label: startup.estagio),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StartupLogo extends StatelessWidget {
+  final String url;
+  final double size;
+
+  const _StartupLogo({
+    required this.url,
+    required this.size,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final placeholder = Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: AppColors.muted,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: const Icon(
+        Icons.business_rounded,
+        color: AppColors.mutedForeground,
+      ),
+    );
+
+    if (url.isEmpty) return placeholder;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: Image.network(
+        url,
+        width: size,
+        height: size,
+        fit: BoxFit.cover,
+        errorBuilder: (_, _, _) => placeholder,
+      ),
+    );
+  }
+}
+
+class _StageChip extends StatelessWidget {
+  final String label;
+
+  const _StageChip({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = switch (label) {
+      'Em Expansao' || 'Em Expansão' => AppColors.stageExpansion,
+      'Em Operacao' || 'Em Operação' => AppColors.stageOperation,
+      'Nova' => AppColors.stageNew,
+      _ => AppColors.mutedForeground,
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: color,
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoSection extends StatelessWidget {
+  final String title;
+  final Widget child;
+
+  const _InfoSection({
+    required this.title,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppColors.card,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: AppColors.muted),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: AppColors.foreground,
+            ),
+          ),
+          const SizedBox(height: 12),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _MetricTile extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _MetricTile({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.secondary,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 20, color: AppColors.primary),
+          const SizedBox(height: 8),
+          Text(
+            label,
+            style: const TextStyle(
+              fontSize: 12,
+              color: AppColors.mutedForeground,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            value,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w700,
+              color: AppColors.foreground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PeopleSection extends StatelessWidget {
+  final String title;
+  final List<Socio> people;
+
+  const _PeopleSection({
+    required this.title,
+    required this.people,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _InfoSection(
+      title: title,
+      child: Column(
+        children: [
+          for (final person in people)
+            _SimpleListTile(
+              title: person.nome,
+              subtitle: '${person.participacao.toStringAsFixed(0)}%',
+              icon: Icons.person_rounded,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MembersSection extends StatelessWidget {
+  final String title;
+  final List<Membro> members;
+
+  const _MembersSection({
+    required this.title,
+    required this.members,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return _InfoSection(
+      title: title,
+      child: Column(
+        children: [
+          for (final member in members)
+            _SimpleListTile(
+              title: member.nome,
+              subtitle: '${member.cargo} - ${member.area}',
+              icon: Icons.badge_rounded,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _UpdatesSection extends StatelessWidget {
+  final List<Atualizacao> updates;
+
+  const _UpdatesSection({required this.updates});
+
+  @override
+  Widget build(BuildContext context) {
+    return _InfoSection(
+      title: 'Atualizacoes',
+      child: Column(
+        children: [
+          for (final update in updates)
+            _SimpleListTile(
+              title: update.titulo,
+              subtitle: update.data.isEmpty
+                  ? update.descricao
+                  : '${update.data} - ${update.descricao}',
+              icon: Icons.campaign_rounded,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SimpleListTile extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+
+  const _SimpleListTile({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(icon, size: 18, color: AppColors.primary),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: AppColors.foreground,
+                  ),
+                ),
+                if (subtitle.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: const TextStyle(
+                      fontSize: 12,
+                      height: 1.4,
+                      color: AppColors.mutedForeground,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatCurrency(double value) {
+  if (value >= 1000000) {
+    return 'R\$ ${(value / 1000000).toStringAsFixed(1)}M';
+  }
+  if (value >= 1000) {
+    return 'R\$ ${(value / 1000).toStringAsFixed(0)}k';
+  }
+  return 'R\$ ${value.toStringAsFixed(0)}';
+}
+
+String _formatTokens(int value) {
+  if (value >= 1000) {
+    return '${(value / 1000).toStringAsFixed(0)}k';
+  }
+  return value.toString();
+}

--- a/mobile/lib/features/startups/presentation/widgets/startup_card.dart
+++ b/mobile/lib/features/startups/presentation/widgets/startup_card.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:mesclainvest/core/theme/app_colors.dart';
+
 import '../../domain/startup_model.dart';
 
 class StartupCard extends StatelessWidget {
-  // Recebe a startup e uma função de callback quando o card é tocado
   final Startup startup;
   final VoidCallback onTap;
 
@@ -13,21 +13,34 @@ class StartupCard extends StatelessWidget {
     required this.onTap,
   });
 
-  // Retorna a cor do chip de estágio conforme o protótipo
   Color _estagioColor(String estagio) {
     switch (estagio) {
       case 'Em Expansão':
-        return AppColors.stageExpansion; // roxo
+      case 'Em Expansao':
+        return AppColors.stageExpansion;
       case 'Em Operação':
-        return AppColors.stageOperation; // azul
+      case 'Em Operacao':
+        return AppColors.stageOperation;
       case 'Nova':
-        return AppColors.stageNew; // verde
+        return AppColors.stageNew;
       default:
         return AppColors.mutedForeground;
     }
   }
 
-  // Formata o capital aportado como "R$ 320k" ou "R$ 1.2M"
+  String _estagioLabel(String estagio) {
+    switch (estagio) {
+      case 'Em Expansão':
+      case 'Em Expansao':
+        return 'Expansão';
+      case 'Em Operação':
+      case 'Em Operacao':
+        return 'Operação';
+      default:
+        return estagio;
+    }
+  }
+
   String _formatarCapital(double valor) {
     if (valor >= 1000000) {
       return 'R\$ ${(valor / 1000000).toStringAsFixed(1)}M';
@@ -37,7 +50,6 @@ class StartupCard extends StatelessWidget {
     return 'R\$ ${valor.toStringAsFixed(0)}';
   }
 
-  // Formata o total de tokens como "50k tokens"
   String _formatarTokens(int tokens) {
     if (tokens >= 1000) {
       return '${(tokens / 1000).toStringAsFixed(0)}k tokens';
@@ -47,127 +59,276 @@ class StartupCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.06),
-              blurRadius: 12,
-              offset: const Offset(0, 4),
-            ),
-          ],
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
+    final stageColor = _estagioColor(startup.estagio);
+    final isPositive = (startup.variacaoPreco ?? 0) >= 0;
+    final variacaoColor = isPositive ? AppColors.success : AppColors.destructive;
 
-            // Linha superior: logo + nome + descrição
-            Row(
-              children: [
-                // Logo da startup
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
-                  child: Image.network(
-                    startup.logo,
-                    width: 48,
-                    height: 48,
-                    fit: BoxFit.cover,
-                    // Fallback se a imagem não carregar
-                    errorBuilder: (_, _, _) => Container(
-                      width: 48,
-                      height: 48,
-                      decoration: BoxDecoration(
-                        color: Colors.grey[200],
-                        borderRadius: BorderRadius.circular(12),
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Material(
+        color: AppColors.card,
+        borderRadius: BorderRadius.circular(16),
+        clipBehavior: Clip.antiAlias,
+        elevation: 0,
+        child: InkWell(
+          onTap: onTap,
+          child: Stack(
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  color: AppColors.card,
+                  borderRadius: BorderRadius.circular(16),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.06),
+                      blurRadius: 12,
+                      offset: const Offset(0, 4),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(
+                        16,
+                        16,
+                        startup.investido ? 80 : 16,
+                        0,
                       ),
-                      child: const Icon(Icons.business, color: Colors.grey),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          _buildLogo(),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  startup.nome,
+                                  style: const TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w700,
+                                    color: Color(0xFF1E293B),
+                                  ),
+                                ),
+                                const SizedBox(height: 2),
+                                Text(
+                                  startup.descricao,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: const TextStyle(
+                                    fontSize: 12,
+                                    color: AppColors.mutedForeground,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Row(
+                        children: [
+                          _buildEstagioChip(stageColor),
+                          if (startup.setor.isNotEmpty) ...[
+                            const SizedBox(width: 6),
+                            Flexible(
+                              child: Text(
+                                startup.setor,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  fontSize: 11,
+                                  color: AppColors.mutedForeground,
+                                ),
+                              ),
+                            ),
+                          ],
+                          const SizedBox(width: 6),
+                          const Text(
+                            '·',
+                            style: TextStyle(color: AppColors.mutedForeground),
+                          ),
+                          const SizedBox(width: 6),
+                          const Icon(
+                            Icons.toll_rounded,
+                            size: 13,
+                            color: AppColors.mutedForeground,
+                          ),
+                          const SizedBox(width: 3),
+                          Text(
+                            _formatarTokens(startup.totalTokens),
+                            style: const TextStyle(
+                              fontSize: 11,
+                              color: AppColors.mutedForeground,
+                            ),
+                          ),
+                          if (startup.capitalAportado > 0) ...[
+                            const SizedBox(width: 6),
+                            const Icon(
+                              Icons.attach_money_rounded,
+                              size: 13,
+                              color: AppColors.mutedForeground,
+                            ),
+                            Text(
+                              _formatarCapital(startup.capitalAportado),
+                              style: const TextStyle(
+                                fontSize: 11,
+                                color: AppColors.mutedForeground,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    const Divider(
+                      height: 1,
+                      thickness: 1,
+                      color: Color(0xFFF1F5F9),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 10, 16, 14),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                const Text(
+                                  'Preço por token',
+                                  style: TextStyle(
+                                    fontSize: 10,
+                                    color: AppColors.mutedForeground,
+                                  ),
+                                ),
+                                const SizedBox(height: 2),
+                                Text(
+                                  startup.precoToken > 0
+                                      ? 'R\$ ${startup.precoToken.toStringAsFixed(2)}'
+                                      : 'Indisponível',
+                                  style: const TextStyle(
+                                    fontSize: 18,
+                                    fontWeight: FontWeight.w700,
+                                    color: Color(0xFF1E293B),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          if (startup.variacaoPreco != null)
+                            _buildVariacaoBadge(isPositive, variacaoColor),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (startup.investido)
+                Positioned(
+                  top: 0,
+                  right: 0,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 5,
+                    ),
+                    decoration: const BoxDecoration(
+                      color: AppColors.primary,
+                      borderRadius: BorderRadius.only(
+                        bottomLeft: Radius.circular(8),
+                      ),
+                    ),
+                    child: const Text(
+                      'INVESTIDO',
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w700,
+                        color: Colors.white,
+                        letterSpacing: 0.5,
+                      ),
                     ),
                   ),
                 ),
-                const SizedBox(width: 12),
-
-                // Nome e descrição
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        startup.nome,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                          color: Color(0xFF1E293B),
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        startup.descricao,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Colors.grey[600],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-
-            const SizedBox(height: 12),
-
-            // Linha do meio: chip de estágio + tokens + capital
-            Row(
-              children: [
-                // Chip de estágio
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 10,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    color: _estagioColor(startup.estagio).withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                  child: Text(
-                    startup.estagio,
-                    style: TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w600,
-                      color: _estagioColor(startup.estagio),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-
-                // Ícone + tokens
-                Icon(Icons.toll, size: 14, color: Colors.grey[500]),
-                const SizedBox(width: 4),
-                Text(
-                  _formatarTokens(startup.totalTokens),
-                  style: TextStyle(fontSize: 12, color: Colors.grey[600]),
-                ),
-                const SizedBox(width: 8),
-
-                // Capital aportado
-                if (startup.capitalAportado > 0) ...[
-                  Icon(Icons.attach_money, size: 14, color: Colors.grey[500]),
-                  Text(
-                    _formatarCapital(startup.capitalAportado),
-                    style: TextStyle(fontSize: 12, color: Colors.grey[600]),
-                  ),
-                ],
-              ],
-            ),
-          ],
+            ],
+          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildLogo() {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: Image.network(
+        startup.logo,
+        width: 52,
+        height: 52,
+        fit: BoxFit.cover,
+        errorBuilder: (_, _, _) => Container(
+          width: 52,
+          height: 52,
+          decoration: BoxDecoration(
+            color: AppColors.muted,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Icon(
+            Icons.business_rounded,
+            color: AppColors.mutedForeground,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEstagioChip(Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        _estagioLabel(startup.estagio),
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVariacaoBadge(bool isPositive, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isPositive ? Icons.north_east_rounded : Icons.south_east_rounded,
+            size: 12,
+            color: color,
+          ),
+          const SizedBox(width: 2),
+          Text(
+            '${startup.variacaoPreco!.abs().toStringAsFixed(1)}%',
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: color,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Mudanças

- nova tela com header, resumo executivo, indicadores (capital e tokens), sócios, conselho, mentores e atualizações
- adicionados endpoints `buscarStartupPorId` e `investirStartup`
- adicionadas classes `Socio`, `Membro` e `Atualizacao`
- navegação para a nova tela ao clicar em um card
- rota `/startup-details` registrada

## Modal de investimento

- Validação em tempo real (saldo insuficiente / abaixo do mínimo)
- Botão "Confirmar" desabilitado enquanto o input é inválido
- `TextEditingController` descartado corretamente após fechamento do diálogo
- Estado local isolado via `StatefulBuilder` — sem vazamento para a tela pai